### PR TITLE
Localhost

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+name: Bedrock Node.js CI
+
+on: [push]
+
+jobs:
+  test-node:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: |
+        cd test
+        npm install
+    - name: Run test with Node.js ${{ matrix.node-version }}
+      run: |
+        cd test
+        npm test
+      env:
+        CI: true
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - name: Run eslint
+      run: npm run lint

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 Bedrock Non-Commercial License v1.0
 ===================================
 
-Copyright (c) 2011-2019 Digital Bazaar, Inc.
+Copyright (c) 2011-2020 Digital Bazaar, Inc.
 All rights reserved.
 
 Summary

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,7 @@
 /*!
  * Bedrock Server Module Configuration
  *
- * Copyright (c) 2012-2019 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2012-2020 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,7 +14,7 @@ const path = require('path');
 config.server = {};
 config.server.port = 18443;
 config.server.httpPort = 18080;
-config.server.domain = 'bedrock.localhost';
+config.server.domain = 'localhost';
 cc('server.bindAddr', () => {
   return [config.server.domain];
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@
  * Once the ports are bound, the process is switched to any configured
  * system user.
  *
- * Copyright (c) 2012-2019 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2012-2020 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/test/mocha/10-test.js
+++ b/test/mocha/10-test.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2014-2019 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/test/package.json
+++ b/test/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "bedrock": "^3.0.0",
     "bedrock-server": "file:..",
-    "bedrock-test": "^4.0.0",
+    "bedrock-test": "^5.2.0",
     "request": "^2.75.0"
   }
 }

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -1,7 +1,7 @@
 /*!
  * Bedrock Server Module test configuration.
  *
- * Copyright (c) 2012-2019 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2012-2020 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2019 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 


### PR DESCRIPTION
Eliminates `bedrock.localhost`.  However, before proceeding with this I would really like to understand the historical reason for why it was `bedrock.local`, then `bedrock.localhost` in the first place.

Also, there is readme stuff for generating the SSL certs that still has `bedrock.localhost` in it which I think is fine to keep.

This eliminates any necessity to setup hosts entries on CI systems and dev machines.  I've been able to test this branch already on github actions.