### PR TITLE
Bump peerDep for bedrock to 1.x - 4.x.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-server ChangeLog
 
+## 2.8.1 - TBD
+
+### Changed
+- Changed peerDependency for `bedrock` to allow 4.x.
+
 ## 2.8.0 - 2021-07-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "spdy": "^4.0.2"
   },
   "peerDependencies": {
-    "bedrock": "1.3.0 - 3.x"
+    "bedrock": "1.3.0 - 4.x"
   },
   "directories": {
     "lib": "./lib"


### PR DESCRIPTION
bumps the peerDep for bedrock to allow 4.x