### PR TITLE
Update node-forge.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 3.1.0 - 2021-TBD
 
+### Changed
+- Use node-forge@1.2.1.
+
 ### Added
 - Setup nyc and add code coverage to github actions.
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "express": "^4.12.0",
     "morgan": "^1.5.2",
-    "node-forge": "^0.10.0"
+    "node-forge": "^1.2.1"
   },
   "peerDependencies": {
     "bedrock": "^4.3.0"


### PR DESCRIPTION
Update to address security advisories.
Note that node-forge may be removed in https://github.com/digitalbazaar/bedrock-server/pull/27.